### PR TITLE
Rename binary from bd to mb in documentation and Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ clean:
 # Install binary to ~/.local/bin
 install: release
 	mkdir -p ~/.local/bin
-	cp target/release/bd ~/.local/bin/
+	cp target/release/mb ~/.local/bin/
 
 # Show help
 help:

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A minimal, markdown-based drop-in replacement for [steveyegge/beads](https://git
 
 ## Overview
 
-minibeads (`bd`) is a dependency-aware issue tracker designed for AI agent workflows. Issues are stored as markdown files with YAML frontmatter, making them both human-readable and git-friendly. The tool emphasizes simplicity, with no database required—just markdown files in `.beads/issues/`.
+minibeads (`mb`) is a dependency-aware issue tracker designed for AI agent workflows. Issues are stored as markdown files with YAML frontmatter, making them both human-readable and git-friendly. The tool emphasizes simplicity, with no database required—just markdown files in `.beads/issues/`.
 
 ### Key Features
 
@@ -33,37 +33,37 @@ make release
 make install
 ```
 
-The binary will be named `bd` (short for "beads").
+The binary will be named `mb` (short for "minibeads").
 
 ## Quick Start
 
 ```bash
 # Initialize a beads database in your project
-bd init
+mb init
 
 # Create your first issue
-bd create "Fix login bug" -p 1 -t bug
+mb create "Fix login bug" -p 1 -t bug
 
 # List all issues
-bd list
+mb list
 
 # Show issue details
-bd show bd-1
+mb show bd-1
 
 # Update issue status
-bd update bd-1 --status in_progress
+mb update bd-1 --status in_progress
 
 # Add dependencies (bd-2 blocks bd-1)
-bd dep add bd-1 bd-2
+mb dep add bd-1 bd-2
 
 # Find ready work (no blockers)
-bd ready
+mb ready
 
 # Get statistics
-bd stats
+mb stats
 ```
 
-Run `bd quickstart` for a comprehensive guide.
+Run `mb quickstart` for a comprehensive guide.
 
 ## Storage Format
 
@@ -174,24 +174,24 @@ minibeads uses coarse-grained locking with `.beads/minibeads.lock` containing th
 
 ### Core Commands
 
-- `bd init [--prefix PREFIX]` - Initialize beads database
-- `bd create TITLE [OPTIONS]` - Create new issue
-- `bd list [FILTERS]` - List issues with optional filters
-- `bd show ISSUE_ID` - Show detailed issue information
-- `bd update ISSUE_ID [OPTIONS]` - Update issue fields
-- `bd close ISSUE_ID [--reason REASON]` - Close (complete) an issue
-- `bd reopen ISSUE_ID...` - Reopen closed issues
+- `mb init [--prefix PREFIX]` - Initialize beads database
+- `mb create TITLE [OPTIONS]` - Create new issue
+- `mb list [FILTERS]` - List issues with optional filters
+- `mb show ISSUE_ID` - Show detailed issue information
+- `mb update ISSUE_ID [OPTIONS]` - Update issue fields
+- `mb close ISSUE_ID [--reason REASON]` - Close (complete) an issue
+- `mb reopen ISSUE_ID...` - Reopen closed issues
 
 ### Dependencies
 
-- `bd dep add FROM TO [--type TYPE]` - Add dependency
+- `mb dep add FROM TO [--type TYPE]` - Add dependency
   - Types: `blocks` (default), `related`, `parent-child`, `discovered-from`
 
 ### Queries
 
-- `bd ready [--assignee USER] [--priority N]` - Find ready work (no blockers)
-- `bd blocked` - Show blocked issues and what blocks them
-- `bd stats` - Show statistics (total, open, blocked, average lead time)
+- `mb ready [--assignee USER] [--priority N]` - Find ready work (no blockers)
+- `mb blocked` - Show blocked issues and what blocks them
+- `mb stats` - Show statistics (total, open, blocked, average lead time)
 
 ### Options
 
@@ -218,7 +218,7 @@ minibeads uses coarse-grained locking with `.beads/minibeads.lock` containing th
 
 ### Migration Path
 
-To export for upstream beads compatibility, use `bd export` (planned in minibeads-11) to generate `issues.jsonl`. Bidirectional sync (minibeads-12) will enable hybrid workflows.
+To export for upstream beads compatibility, use `mb export` (planned in minibeads-11) to generate `issues.jsonl`. Bidirectional sync (minibeads-12) will enable hybrid workflows.
 
 ## Roadmap
 


### PR DESCRIPTION
Update all references from 'bd' to 'mb' (minibeads) to reflect the actual binary name and avoid confusion with upstream beads.

## Changes
- **README.md**: Replace all 'bd' command examples with 'mb'
- **README.md**: Update binary name description from 'bd (short for beads)' to 'mb (short for minibeads)'
- **Makefile**: Fix install target to copy 'mb' instead of 'bd'

This makes the documentation consistent with the actual binary produced by the build process.

## Testing
- Documentation changes only, no code changes
- Build verified to produce 'mb' binary